### PR TITLE
fix:  duplicate restart key in hocus-local.yml db service

### DIFF
--- a/ops/docker/hocus-local.yml
+++ b/ops/docker/hocus-local.yml
@@ -57,7 +57,6 @@ services:
 
   db:
     image: "postgres:15.2-alpine"
-    restart: unless-stopped
     depends_on:
       setup-keycloak:
         condition: service_completed_successfully


### PR DESCRIPTION
hocus-local.yml has duplicate key `restart` which cause error:

```shell
➜  hocus git:(main) ops/bin/local-down.sh
yaml: unmarshal errors:
  line 71: mapping key "restart" already defined at line 60
```

> there's another restart config in line 70