### PR TITLE
HOC-179 - handle prebuild errors

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -18,7 +18,7 @@ PERF_MONITORING_ENABLED=1
 
 This will build test VM's, attach to the running Hocus agent and start an E2E test suite using https://github.com/hocus-dev/tests
 
-You may also attach to the agent container manually and run:
+You may also attach to the agent container manually. The following will run a single E2E test of the prebuild workflow:
 
 ```bash
 yarn jest 'app/agent/workflows.test.ts' -t 'runBuildfsAndPrebuilds' --testTimeout 600000

--- a/README.dev.md
+++ b/README.dev.md
@@ -18,6 +18,12 @@ PERF_MONITORING_ENABLED=1
 
 This will build test VM's, attach to the running Hocus agent and start an E2E test suite using https://github.com/hocus-dev/tests
 
+You may also attach to the agent container manually and run:
+
+```bash
+yarn jest 'app/agent/workflows.test.ts' -t 'runBuildfsAndPrebuilds' --testTimeout 600000
+```
+
 ## To add another buildkite runner
 
 ```bash

--- a/app/agent/activities/buildfs.ts
+++ b/app/agent/activities/buildfs.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 
 import type { CreateActivity } from "./types";
+import { withActivityHeartbeat } from "./utils";
 
 import { Token } from "~/token";
 
@@ -16,7 +17,9 @@ export const buildfs: CreateActivity<BuildfsActivity> =
     const perfService = injector.resolve(Token.PerfService);
 
     perfService.log("buildfs", "start", args.buildfsEventId);
-    const result = await buildfsService.buildfs({ ...args, db, firecrackerService });
+    const result = await withActivityHeartbeat({ intervalMs: 5000 }, () =>
+      buildfsService.buildfs({ ...args, db, firecrackerService }),
+    );
     perfService.log("buildfs", "end", args.buildfsEventId);
 
     return result;

--- a/app/agent/activities/cancel-prebuilds.ts
+++ b/app/agent/activities/cancel-prebuilds.ts
@@ -3,15 +3,18 @@ import type { CreateActivity } from "./types";
 import { Token } from "~/token";
 import { waitForPromises } from "~/utils.shared";
 
-export type CancelPrebuildsActivity = (prebuildEventIds: bigint[]) => Promise<void>;
+export type CancelPrebuildsActivity = (
+  prebuildEventIds: bigint[],
+  errorMessage?: string,
+) => Promise<void>;
 export const cancelPrebuilds: CreateActivity<CancelPrebuildsActivity> =
   ({ injector, db }) =>
-  async (prebuildEventIds) => {
+  async (prebuildEventIds, errorMessage) => {
     const prebuildService = injector.resolve(Token.PrebuildService);
     await waitForPromises(
       prebuildEventIds.map((prebuildEventId) =>
         db.$transaction((tdb) =>
-          prebuildService.cleanupDbAfterPrebuildError(tdb, prebuildEventId, "Image build failed"),
+          prebuildService.cleanupDbAfterPrebuildError(tdb, prebuildEventId, errorMessage),
         ),
       ),
     );

--- a/app/agent/activities/cancel-prebuilds.ts
+++ b/app/agent/activities/cancel-prebuilds.ts
@@ -1,11 +1,18 @@
 import type { CreateActivity } from "./types";
 
 import { Token } from "~/token";
+import { waitForPromises } from "~/utils.shared";
 
 export type CancelPrebuildsActivity = (prebuildEventIds: bigint[]) => Promise<void>;
 export const cancelPrebuilds: CreateActivity<CancelPrebuildsActivity> =
   ({ injector, db }) =>
   async (prebuildEventIds) => {
     const prebuildService = injector.resolve(Token.PrebuildService);
-    await db.$transaction((tdb) => prebuildService.cancelPrebuilds(tdb, prebuildEventIds));
+    await waitForPromises(
+      prebuildEventIds.map((prebuildEventId) =>
+        db.$transaction((tdb) =>
+          prebuildService.cleanupDbAfterPrebuildError(tdb, prebuildEventId, "Image build failed"),
+        ),
+      ),
+    );
   };

--- a/app/agent/activities/checkout-and-inspect.ts
+++ b/app/agent/activities/checkout-and-inspect.ts
@@ -3,6 +3,7 @@ import { SOLO_AGENT_INSTANCE_ID } from "../constants";
 import { randomString } from "../utils";
 
 import type { CreateActivity } from "./types";
+import { withActivityHeartbeat } from "./utils";
 
 import { Token } from "~/token";
 import { unwrap } from "~/utils.shared";
@@ -38,24 +39,28 @@ export const checkoutAndInspect: CreateActivity<CheckoutAndInspectActivity> =
     const prebuildService = injector.resolve(Token.PrebuildService);
     const perfService = injector.resolve(Token.PerfService);
     perfService.log("checkoutAndInspect", "start", args.gitRepositoryId, args.targetBranch);
-    const gitRepository = await db.gitRepository.findUniqueOrThrow({
-      where: { id: args.gitRepositoryId },
-      include: {
-        gitRepositoryFiles: { include: { agentInstance: true, file: true } },
-      },
+
+    const result = await withActivityHeartbeat({ intervalMs: 5000 }, async () => {
+      const gitRepository = await db.gitRepository.findUniqueOrThrow({
+        where: { id: args.gitRepositoryId },
+        include: {
+          gitRepositoryFiles: { include: { agentInstance: true, file: true } },
+        },
+      });
+      const repoFile = unwrap(
+        gitRepository.gitRepositoryFiles.find(
+          (f) => f.agentInstance.externalId === SOLO_AGENT_INSTANCE_ID,
+        ),
+      );
+      return await prebuildService.checkoutAndInspect({
+        fcService,
+        repositoryDrivePath: repoFile.file.path,
+        targetBranch: args.targetBranch,
+        outputDrivePath: args.outputDrivePath,
+        projectConfigPaths: args.projectConfigPaths,
+      });
     });
-    const repoFile = unwrap(
-      gitRepository.gitRepositoryFiles.find(
-        (f) => f.agentInstance.externalId === SOLO_AGENT_INSTANCE_ID,
-      ),
-    );
-    const result = await prebuildService.checkoutAndInspect({
-      fcService,
-      repositoryDrivePath: repoFile.file.path,
-      targetBranch: args.targetBranch,
-      outputDrivePath: args.outputDrivePath,
-      projectConfigPaths: args.projectConfigPaths,
-    });
+
     perfService.log("checkoutAndInspect", "end", args.gitRepositoryId, args.targetBranch);
     return result;
   };

--- a/app/agent/activities/clean-up-after-prebuild-error.ts
+++ b/app/agent/activities/clean-up-after-prebuild-error.ts
@@ -14,7 +14,7 @@ export const cleanUpAfterPrebuildError: CreateActivity<CleanUpAfterPrebuildError
     await waitForPromises(
       args.prebuildEventIds.map((prebuildEventId) =>
         db.$transaction((tdb) =>
-          // TODO: clean up local files too
+          // TODO: clean up local files too once we rewrite how storage is handled in general
           prebuildService.cleanupDbAfterPrebuildError(tdb, prebuildEventId, args.errorMessage),
         ),
       ),

--- a/app/agent/activities/clean-up-after-prebuild-error.ts
+++ b/app/agent/activities/clean-up-after-prebuild-error.ts
@@ -1,0 +1,22 @@
+import type { CreateActivity } from "./types";
+
+import { Token } from "~/token";
+import { waitForPromises } from "~/utils.shared";
+
+export type CleanUpAfterPrebuildErrorActivity = (args: {
+  prebuildEventIds: bigint[];
+  errorMessage: string;
+}) => Promise<void>;
+export const cleanUpAfterPrebuildError: CreateActivity<CleanUpAfterPrebuildErrorActivity> =
+  ({ injector, db }) =>
+  async (args) => {
+    const prebuildService = injector.resolve(Token.PrebuildService);
+    await waitForPromises(
+      args.prebuildEventIds.map((prebuildEventId) =>
+        db.$transaction((tdb) =>
+          // TODO: clean up local files too
+          prebuildService.cleanupDbAfterPrebuildError(tdb, prebuildEventId, args.errorMessage),
+        ),
+      ),
+    );
+  };

--- a/app/agent/activities/list.ts
+++ b/app/agent/activities/list.ts
@@ -26,6 +26,8 @@ import type { ChangePrebuildEventStatusActivity } from "./change-prebuild-event-
 import { changePrebuildEventStatus } from "./change-prebuild-event-status";
 import type { CheckoutAndInspectActivity } from "./checkout-and-inspect";
 import { checkoutAndInspect } from "./checkout-and-inspect";
+import type { CleanUpAfterPrebuildErrorActivity } from "./clean-up-after-prebuild-error";
+import { cleanUpAfterPrebuildError } from "./clean-up-after-prebuild-error";
 import type { CreatePrebuildFilesActivity } from "./create-prebuild-files";
 import { createPrebuildFiles } from "./create-prebuild-files";
 import type { CreateWorkspaceActivity } from "./create-workspace";
@@ -95,6 +97,7 @@ export interface Activities {
   deleteRemovablePrebuildEvents: DeleteRemovablePrebuildEventsActivity;
   getArchivablePrebuildEvents: GetArchivablePrebuildEventsActivity;
   saveGitRepoConnectionStatus: SaveGitRepoConnectionStatusActivity;
+  cleanUpAfterPrebuildError: CleanUpAfterPrebuildErrorActivity;
 }
 
 export interface ActivityArgs {
@@ -141,6 +144,7 @@ export const createActivities = async (
     deleteRemovablePrebuildEvents,
     getArchivablePrebuildEvents,
     saveGitRepoConnectionStatus,
+    cleanUpAfterPrebuildError,
   };
 
   return Object.fromEntries(

--- a/app/agent/activities/prebuild.ts
+++ b/app/agent/activities/prebuild.ts
@@ -24,7 +24,7 @@ export const prebuild: CreateActivity<PrebuildActivity> =
     const firecrackerService = injector.resolve(Token.FirecrackerService)(instanceId);
     const prebuildService = injector.resolve(Token.PrebuildService);
 
-    return await withActivityHeartbeat({ intervalMs: 10000 }, () =>
+    return await withActivityHeartbeat({ intervalMs: 5000 }, () =>
       prebuildService.prebuild(db, firecrackerService, args.prebuildEventId),
     );
   };

--- a/app/agent/activities/prebuild.ts
+++ b/app/agent/activities/prebuild.ts
@@ -1,15 +1,11 @@
-import path from "path";
-
 import { v4 as uuidv4 } from "uuid";
 
 import type { VMTaskOutput } from "../agent-util.types";
-import { SOLO_AGENT_INSTANCE_ID, WORKSPACE_ENV_SCRIPT_PATH } from "../constants";
 
 import type { CreateActivity } from "./types";
+import { withActivityHeartbeat } from "./utils";
 
-import { execSshCmd } from "~/agent/utils";
 import { Token } from "~/token";
-import { unwrap } from "~/utils.shared";
 
 export type PrebuildActivity = (args: { prebuildEventId: bigint }) => Promise<VMTaskOutput[]>;
 /**
@@ -26,79 +22,9 @@ export const prebuild: CreateActivity<PrebuildActivity> =
     const runId = uuidv4();
     const instanceId = `prebuild-${runId}`;
     const firecrackerService = injector.resolve(Token.FirecrackerService)(instanceId);
-    const agentUtilService = injector.resolve(Token.AgentUtilService);
     const prebuildService = injector.resolve(Token.PrebuildService);
-    const perfService = injector.resolve(Token.PerfService);
-    const agentConfig = injector.resolve(Token.Config).agent();
 
-    perfService.log("prebuild", "start", args.prebuildEventId);
-    const prebuildEvent = await db.prebuildEvent.findUniqueOrThrow({
-      where: { id: args.prebuildEventId },
-      include: {
-        tasks: { include: { vmTask: true } },
-        prebuildEventFiles: { include: { agentInstance: true, fsFile: true, projectFile: true } },
-        project: {
-          include: {
-            environmentVariableSet: {
-              include: {
-                environmentVariables: true,
-              },
-            },
-          },
-        },
-      },
-    });
-    const prebuildEventFiles = unwrap(
-      prebuildEvent.prebuildEventFiles.find(
-        (f) => f.agentInstance.externalId === SOLO_AGENT_INSTANCE_ID,
-      ),
+    return await withActivityHeartbeat({ intervalMs: 10000 }, () =>
+      prebuildService.prebuild(db, firecrackerService, args.prebuildEventId),
     );
-    const envVariables = prebuildEvent.project.environmentVariableSet.environmentVariables.map(
-      (v) => ({
-        name: v.name,
-        value: v.value,
-      }),
-    );
-    const tasks = prebuildEvent.tasks;
-    const result = await firecrackerService.withVM(
-      {
-        ssh: {
-          username: "hocus",
-          privateKey: agentConfig.prebuildSshPrivateKey,
-        },
-        kernelPath: agentConfig.defaultKernel,
-        rootFsPath: prebuildEventFiles.fsFile.path,
-        extraDrives: [
-          {
-            pathOnHost: prebuildEventFiles.projectFile.path,
-            guestMountPath: prebuildService.devDir,
-          },
-        ],
-        memSizeMib: prebuildEvent.project.maxPrebuildRamMib,
-        vcpuCount: prebuildEvent.project.maxPrebuildVCPUCount,
-      },
-      async ({ ssh, sshConfig }) => {
-        const envScript = agentUtilService.generateEnvVarsScript(envVariables);
-        await execSshCmd({ ssh }, ["mkdir", "-p", path.dirname(WORKSPACE_ENV_SCRIPT_PATH)]);
-        await agentUtilService.writeFile(ssh, WORKSPACE_ENV_SCRIPT_PATH, envScript);
-        await Promise.all(
-          tasks.map(async (task) => {
-            const script = agentUtilService.generatePrebuildTaskScript(task.originalCommand);
-            const paths = prebuildService.getPrebuildTaskPaths(task.idx);
-            await execSshCmd({ ssh }, ["mkdir", "-p", prebuildService.prebuildScriptsDir]);
-            await agentUtilService.writeFile(ssh, paths.scriptPath, script);
-          }),
-        );
-
-        return await agentUtilService.execVmTasks(
-          sshConfig,
-          db,
-          tasks.map((t) => ({
-            vmTaskId: t.vmTask.id,
-          })),
-        );
-      },
-    );
-    perfService.log("prebuild", "end", args.prebuildEventId);
-    return result;
   };

--- a/app/agent/activities/utils.ts
+++ b/app/agent/activities/utils.ts
@@ -1,0 +1,24 @@
+import { Context } from "@temporalio/activity";
+
+export const withActivityHeartbeat = <T>(
+  options: {
+    /** Default: 5000 */
+    intervalMs?: number;
+  },
+  fn: (...args: any[]) => Promise<T>,
+): Promise<T> => {
+  return new Promise((resolve, reject) => {
+    const interval = setInterval(() => {
+      Context.current().heartbeat();
+    }, options.intervalMs ?? 5000);
+
+    fn()
+      .then((result) => {
+        resolve(result);
+      })
+      .catch((err) => {
+        reject(err);
+      })
+      .finally(() => clearInterval(interval));
+  });
+};

--- a/app/agent/activities/utils.ts
+++ b/app/agent/activities/utils.ts
@@ -14,11 +14,12 @@ export const withActivityHeartbeat = <T>(
 
     fn()
       .then((result) => {
+        clearInterval(interval);
         resolve(result);
       })
       .catch((err) => {
+        clearInterval(interval);
         reject(err);
-      })
-      .finally(() => clearInterval(interval));
+      });
   });
 };

--- a/app/agent/activities/wait-for-buildfs.ts
+++ b/app/agent/activities/wait-for-buildfs.ts
@@ -3,6 +3,7 @@ import { VmTaskStatus } from "@prisma/client";
 import { retry } from "../utils";
 
 import type { CreateActivity } from "./types";
+import { withActivityHeartbeat } from "./utils";
 
 import { sleep } from "~/utils.shared";
 
@@ -15,31 +16,33 @@ export type WaitForBuildfsActivity = (buildfsEventId: bigint, timeoutMs: number)
 export const waitForBuildfs: CreateActivity<WaitForBuildfsActivity> =
   ({ db }) =>
   async (buildfsEventId, timeoutMs) => {
-    const startAt = Date.now();
-    while (true) {
-      const buildfsEvent = await retry(
-        () =>
-          db.buildfsEvent.findUnique({
-            where: { id: buildfsEventId },
-            include: {
-              vmTask: true,
-            },
-          }),
-        5,
-        250,
-      );
-      if (!buildfsEvent) {
-        throw new Error("Buildfs event not found");
+    await withActivityHeartbeat({ intervalMs: 5000 }, async () => {
+      const startAt = Date.now();
+      while (true) {
+        const buildfsEvent = await retry(
+          () =>
+            db.buildfsEvent.findUnique({
+              where: { id: buildfsEventId },
+              include: {
+                vmTask: true,
+              },
+            }),
+          5,
+          250,
+        );
+        if (!buildfsEvent) {
+          throw new Error("Buildfs event not found");
+        }
+        if (buildfsEvent.vmTask.status === VmTaskStatus.VM_TASK_STATUS_SUCCESS) {
+          return;
+        }
+        if (FAILED_STATES.includes(buildfsEvent.vmTask.status as any)) {
+          throw new Error(`Buildfs is in ${buildfsEvent.vmTask.status} state`);
+        }
+        if (Date.now() - startAt > timeoutMs) {
+          throw new Error("Timeout waiting for buildfs");
+        }
+        await sleep(2500);
       }
-      if (buildfsEvent.vmTask.status === VmTaskStatus.VM_TASK_STATUS_SUCCESS) {
-        return;
-      }
-      if (FAILED_STATES.includes(buildfsEvent.vmTask.status as any)) {
-        throw new Error(`Buildfs is in ${buildfsEvent.vmTask.status} state`);
-      }
-      if (Date.now() - startAt > timeoutMs) {
-        throw new Error("Timeout waiting for buildfs");
-      }
-      await sleep(2500);
-    }
+    });
   };

--- a/app/agent/buildfs.service.ts
+++ b/app/agent/buildfs.service.ts
@@ -189,6 +189,11 @@ export class BuildfsService {
         buildfsEvent: {
           cacheHash,
           projectId,
+          vmTask: {
+            status: {
+              notIn: [VmTaskStatus.VM_TASK_STATUS_CANCELLED, VmTaskStatus.VM_TASK_STATUS_ERROR],
+            },
+          },
         },
       },
       include: {

--- a/app/agent/firecracker.service.test.ts
+++ b/app/agent/firecracker.service.test.ts
@@ -94,7 +94,7 @@ test.concurrent(
         rootFsPath: agentConfig.fetchRepositoryRootFs,
         copyRootFs: true,
         removeVmDirAfterPoweroff: false,
-        memSizeMib: 1024,
+        memSizeMib: 128,
         vcpuCount: 1,
       },
       async () => {

--- a/app/agent/prebuild-constants.ts
+++ b/app/agent/prebuild-constants.ts
@@ -1,3 +1,17 @@
+import { PrebuildEventStatus } from "@prisma/client";
+
 export const PREBUILD_DEV_DIR = "/home/hocus/dev" as const;
 export const PREBUILD_REPOSITORY_DIR = `${PREBUILD_DEV_DIR}/project` as const;
 export const PREBUILD_SCRIPTS_DIR = `${PREBUILD_DEV_DIR}/.hocus/init` as const;
+export const SUCCESSFUL_PREBUILD_STATES = [
+  PrebuildEventStatus.PREBUILD_EVENT_STATUS_SUCCESS,
+  PrebuildEventStatus.PREBUILD_EVENT_STATUS_PENDING_ARCHIVE,
+  PrebuildEventStatus.PREBUILD_EVENT_STATUS_ARCHIVED,
+] as const;
+export const UNSUCCESSFUL_PREBUILD_STATES = [
+  PrebuildEventStatus.PREBUILD_EVENT_STATUS_ERROR,
+  PrebuildEventStatus.PREBUILD_EVENT_STATUS_CANCELLED,
+  PrebuildEventStatus.PREBUILD_EVENT_STATUS_PENDING_INIT,
+  PrebuildEventStatus.PREBUILD_EVENT_STATUS_PENDING_READY,
+  PrebuildEventStatus.PREBUILD_EVENT_STATUS_RUNNING,
+] as const;

--- a/app/agent/prebuild.service.ts
+++ b/app/agent/prebuild.service.ts
@@ -422,30 +422,6 @@ export class PrebuildService {
     });
   }
 
-  async cancelPrebuilds(db: Prisma.TransactionClient, prebuildEventIds: bigint[]): Promise<void> {
-    const updatedPrebuildEventsCount = await db.prebuildEvent.updateMany({
-      where: { id: { in: prebuildEventIds } },
-      data: { status: PrebuildEventStatus.PREBUILD_EVENT_STATUS_CANCELLED },
-    });
-    if (updatedPrebuildEventsCount.count !== prebuildEventIds.length) {
-      throw new Error(
-        `Updated ${updatedPrebuildEventsCount.count} rows, expected ${prebuildEventIds.length}`,
-      );
-    }
-    const prebuildEvents = await db.prebuildEvent.findMany({
-      where: { id: { in: prebuildEventIds } },
-      include: { tasks: true },
-    });
-    const taskIds = prebuildEvents.flatMap((e) => e.tasks.map((t) => t.vmTaskId));
-
-    await db.vmTask.updateMany({
-      where: {
-        id: { in: taskIds },
-      },
-      data: { status: VmTaskStatus.VM_TASK_STATUS_CANCELLED },
-    });
-  }
-
   async reservePrebuildEvent(
     db: Prisma.TransactionClient,
     prebuildEventId: bigint,

--- a/app/agent/prebuild.service.ts
+++ b/app/agent/prebuild.service.ts
@@ -578,7 +578,7 @@ export class PrebuildService {
   async cleanupDbAfterPrebuildError(
     db: Prisma.TransactionClient,
     prebuildEventId: bigint,
-    errorMessage: string,
+    errorMessage?: string,
   ): Promise<void> {
     const prebuildEvent = await db.prebuildEvent.findUniqueOrThrow({
       where: { id: prebuildEventId },
@@ -612,12 +612,14 @@ export class PrebuildService {
       where: { id: prebuildEventId },
       data: { status: PrebuildEventStatus.PREBUILD_EVENT_STATUS_ERROR },
     });
-    await db.prebuildEventSystemError.create({
-      data: {
-        prebuildEventId,
-        message: errorMessage,
-      },
-    });
+    if (errorMessage != null) {
+      await db.prebuildEventSystemError.create({
+        data: {
+          prebuildEventId,
+          message: errorMessage,
+        },
+      });
+    }
   }
 
   /**

--- a/app/agent/workflows-utils.ts
+++ b/app/agent/workflows-utils.ts
@@ -1,15 +1,22 @@
 import { ActivityFailure } from "@temporalio/workflow";
 
+const getErrorMessage = (error: Error): string => {
+  if (error.stack != null) {
+    return `${error.message}\n${error.stack}`;
+  }
+  return error.message;
+};
+
 export const parseWorkflowError = (error: unknown): string => {
   const unknownReasonMsg = "Please check Hocus agent logs for more details.";
   if (error instanceof ActivityFailure) {
     if (error.cause instanceof Error) {
-      return error.cause.message;
+      return getErrorMessage(error.cause);
     }
     return unknownReasonMsg;
   }
   if (error instanceof Error) {
-    return error.message;
+    return getErrorMessage(error);
   }
   return unknownReasonMsg;
 };

--- a/app/agent/workflows-utils.ts
+++ b/app/agent/workflows-utils.ts
@@ -1,6 +1,6 @@
 import { ActivityFailure } from "@temporalio/workflow";
 
-export const parseGitSyncError = (error: unknown): string => {
+export const parseWorkflowError = (error: unknown): string => {
   const unknownReasonMsg = "Please check Hocus agent logs for more details.";
   if (error instanceof ActivityFailure) {
     if (error.cause instanceof Error) {

--- a/app/agent/workflows.test.ts
+++ b/app/agent/workflows.test.ts
@@ -226,7 +226,7 @@ test.concurrent(
           {
             project: projects[0],
             buildfsStatus: VmTaskStatus.VM_TASK_STATUS_ERROR,
-            prebuildStatus: PrebuildEventStatus.PREBUILD_EVENT_STATUS_CANCELLED,
+            prebuildStatus: PrebuildEventStatus.PREBUILD_EVENT_STATUS_ERROR,
           },
           {
             project: projects[1],

--- a/app/agent/workflows/index.ts
+++ b/app/agent/workflows/index.ts
@@ -12,7 +12,7 @@ import {
 import { runBuildfsAndPrebuilds, runPrebuild, runBuildfs } from "./prebuild";
 
 import type { Activities } from "~/agent/activities/list";
-import { parseGitSyncError } from "~/agent/workflows-utils";
+import { parseWorkflowError } from "~/agent/workflows-utils";
 import { retryWorkflow, waitForPromisesWorkflow } from "~/temporal/utils";
 import { numericSort, unwrap, groupBy } from "~/utils.shared";
 
@@ -208,7 +208,7 @@ export async function runSyncGitRepository(
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error(err);
-      await saveGitRepoConnectionStatus({ gitRepositoryId, error: parseGitSyncError(err) }).catch(
+      await saveGitRepoConnectionStatus({ gitRepositoryId, error: parseWorkflowError(err) }).catch(
         (err) =>
           // eslint-disable-next-line no-console
           console.error(err),

--- a/app/agent/workflows/index.ts
+++ b/app/agent/workflows/index.ts
@@ -13,13 +13,12 @@ import {
 // the native path module is a restricted import in workflows
 import path from "path-browserify";
 
-import type { CheckoutAndInspectResult } from "./activities-types";
-import type { Activities } from "./activities/list";
-import { HOST_PERSISTENT_DIR } from "./constants";
-import { PREBUILD_REPOSITORY_DIR } from "./prebuild-constants";
-import { ArbitraryKeyMap } from "./utils/arbitrary-key-map.server";
-import { parseGitSyncError } from "./workflows-utils";
-
+import type { CheckoutAndInspectResult } from "~/agent/activities-types";
+import type { Activities } from "~/agent/activities/list";
+import { HOST_PERSISTENT_DIR } from "~/agent/constants";
+import { PREBUILD_REPOSITORY_DIR } from "~/agent/prebuild-constants";
+import { ArbitraryKeyMap } from "~/agent/utils/arbitrary-key-map.server";
+import { parseGitSyncError } from "~/agent/workflows-utils";
 import { retryWorkflow, waitForPromisesWorkflow } from "~/temporal/utils";
 import {
   numericOrNullSort,
@@ -113,7 +112,7 @@ export async function runBuildfsAndPrebuilds(prebuildEventIds: bigint[]): Promis
   }
   const projectAndGitObjectIdToPrebuildEvent = new ArbitraryKeyMap<
     { projectId: bigint; gitObjectId: bigint },
-    (typeof prebuildEvents)[0]
+    typeof prebuildEvents[0]
   >(({ projectId, gitObjectId }) => `${projectId}-${gitObjectId}`);
   for (const prebuildEvent of prebuildEvents) {
     const key = { projectId: prebuildEvent.projectId, gitObjectId: prebuildEvent.gitObjectId };
@@ -166,7 +165,7 @@ export async function runBuildfsAndPrebuilds(prebuildEventIds: bigint[]): Promis
     }),
   );
 
-  const prebuildEventsWithInspection: ((typeof prebuildEvents)[0] & {
+  const prebuildEventsWithInspection: (typeof prebuildEvents[0] & {
     inspection: CheckoutAndInspectResult;
   })[] = [];
   for (const [

--- a/app/agent/workflows/index.ts
+++ b/app/agent/workflows/index.ts
@@ -6,50 +6,26 @@ import {
   startChild,
   sleep,
   continueAsNew,
-  ApplicationFailure,
   ParentClosePolicy,
-  proxySinks,
 } from "@temporalio/workflow";
-// the native path module is a restricted import in workflows
-import path from "path-browserify";
 
-import type { CheckoutAndInspectResult } from "~/agent/activities-types";
+import { runBuildfsAndPrebuilds, runPrebuild, runBuildfs } from "./prebuild";
+
 import type { Activities } from "~/agent/activities/list";
-import { HOST_PERSISTENT_DIR } from "~/agent/constants";
-import { PREBUILD_REPOSITORY_DIR } from "~/agent/prebuild-constants";
-import { ArbitraryKeyMap } from "~/agent/utils/arbitrary-key-map.server";
 import { parseGitSyncError } from "~/agent/workflows-utils";
 import { retryWorkflow, waitForPromisesWorkflow } from "~/temporal/utils";
-import {
-  numericOrNullSort,
-  numericSort,
-  filterNull,
-  unwrap,
-  groupBy,
-  displayError,
-} from "~/utils.shared";
+import { numericSort, unwrap, groupBy } from "~/utils.shared";
 
-const { defaultWorkflowLogger: logger } = proxySinks();
+export { runBuildfsAndPrebuilds, runPrebuild, runBuildfs };
 
 const {
-  checkoutAndInspect,
-  fetchRepository,
-  getOrCreateBuildfsEvents,
-  getPrebuildEvents,
-  buildfs,
-  prebuild,
-  createPrebuildFiles,
   createWorkspace,
   startWorkspace,
   stopWorkspace,
-  cancelPrebuilds,
-  changePrebuildEventStatus,
   getWorkspaceInstanceStatus,
   addProjectAndRepository,
   deleteWorkspace,
-  initPrebuildEvents,
   linkGitBranches,
-  waitForBuildfs,
   reservePrebuildEvent,
   removePrebuildEventReservation,
   waitForPrebuildEventReservations,
@@ -81,233 +57,6 @@ const {
     maximumAttempts: 1,
   },
 });
-
-/**
- * WARNING: This is the hairiest function in the codebase.
- * Prepare to spend a while understanding it.
- *
- * All projects must be from the same repository, otherwise
- * this workflow will fail.
- *
- * Here's what this workflow does:
- *
- * - Fetch the repository
- * - Checkout the git objects and inspect the project configs
- * - Create buildfs events in the db
- * - Create prebuild events in the db
- * - Run buildfs tasks
- * - Run prebuild tasks
- */
-export async function runBuildfsAndPrebuilds(prebuildEventIds: bigint[]): Promise<void> {
-  if (prebuildEventIds.length === 0) {
-    return;
-  }
-  const prebuildEvents = await getPrebuildEvents(prebuildEventIds);
-  const gitRepositoryId = prebuildEvents[0].project.gitRepositoryId;
-  if (!prebuildEvents.every((e) => e.project.gitRepositoryId === gitRepositoryId)) {
-    throw new ApplicationFailure("All projects must be from the same repository");
-  }
-  if (!prebuildEvents.every((e) => e.status === "PREBUILD_EVENT_STATUS_PENDING_INIT")) {
-    throw new ApplicationFailure("All prebuild events must be in the pending init state");
-  }
-  const projectAndGitObjectIdToPrebuildEvent = new ArbitraryKeyMap<
-    { projectId: bigint; gitObjectId: bigint },
-    typeof prebuildEvents[0]
-  >(({ projectId, gitObjectId }) => `${projectId}-${gitObjectId}`);
-  for (const prebuildEvent of prebuildEvents) {
-    const key = { projectId: prebuildEvent.projectId, gitObjectId: prebuildEvent.gitObjectId };
-    if (projectAndGitObjectIdToPrebuildEvent.has(key)) {
-      throw new ApplicationFailure(
-        "There are multiple prebuild events for the same project and git object",
-      );
-    }
-    projectAndGitObjectIdToPrebuildEvent.set(key, prebuildEvent);
-  }
-
-  await fetchRepository(gitRepositoryId);
-  const gitObjectsById = new Map(prebuildEvents.map((e) => [e.gitObjectId, e.gitObject]));
-  const projectsById = new Map(prebuildEvents.map((e) => [e.projectId, e.project]));
-
-  const checkoutId = uuid4();
-  const gitObjectIdToCheckOutPath = new Map(
-    Array.from(gitObjectsById.values()).map((o) => [
-      o.id,
-      `${HOST_PERSISTENT_DIR}/checked-out/${checkoutId}-${o.id}.ext4` as const,
-    ]),
-  );
-  const gitObjectIdsAndProjectIds = Array.from(
-    groupBy(
-      prebuildEvents,
-      (e) => e.gitObjectId,
-      (e) => e.projectId,
-    ).entries(),
-  )
-    .map(
-      ([gitObjectId, projectIds]) =>
-        [gitObjectId, Array.from(new Set(projectIds).values()).sort(numericSort)] as const,
-    )
-    .sort(([a], [b]) => numericSort(a, b));
-
-  const checkedOutResults = await waitForPromisesWorkflow(
-    gitObjectIdsAndProjectIds.map(([gitObjectId, gitObjectProjectIds]) => {
-      const gitObject = unwrap(gitObjectsById.get(gitObjectId));
-      const projectConfigPaths = gitObjectProjectIds.map(
-        (projectId) => unwrap(projectsById.get(projectId)).rootDirectoryPath,
-      );
-      const outputDrivePath = unwrap(gitObjectIdToCheckOutPath.get(gitObjectId));
-
-      return checkoutAndInspect({
-        gitRepositoryId,
-        outputDrivePath,
-        targetBranch: gitObject.hash,
-        projectConfigPaths,
-      });
-    }),
-  );
-
-  const prebuildEventsWithInspection: (typeof prebuildEvents[0] & {
-    inspection: CheckoutAndInspectResult;
-  })[] = [];
-  for (const [
-    gitObjectIdIdx,
-    [gitObjectId, gitObjectProjectIds],
-  ] of gitObjectIdsAndProjectIds.entries()) {
-    for (const [projectIdIdx, projectId] of gitObjectProjectIds.entries()) {
-      const checkoutResult = checkedOutResults[gitObjectIdIdx][projectIdIdx];
-      const prebuildEvent = unwrap(
-        projectAndGitObjectIdToPrebuildEvent.get({ projectId, gitObjectId }),
-      );
-      prebuildEventsWithInspection.push({
-        ...prebuildEvent,
-        inspection: checkoutResult,
-      });
-    }
-  }
-  prebuildEventsWithInspection.sort((a, b) => numericSort(a.id, b.id));
-
-  const buildfsEventsArgs = filterNull(
-    prebuildEventsWithInspection.map(({ inspection, id, gitObjectId, project }) => {
-      if (inspection === null) {
-        return null;
-      }
-      return {
-        prebuildEventId: id,
-        projectId: project.id,
-        contextPath: inspection.projectConfig.image.buildContext,
-        dockerfilePath: inspection.projectConfig.image.file,
-        cacheHash: inspection.imageFileHash,
-        outputFilePath: `${HOST_PERSISTENT_DIR}/buildfs/${uuid4()}.ext4` as const,
-        projectFilePath: unwrap(gitObjectIdToCheckOutPath.get(gitObjectId)),
-      };
-    }),
-  );
-
-  const buildfsEvents = await getOrCreateBuildfsEvents(buildfsEventsArgs);
-  const buildfsEventByPrebuildEventId = new Map(
-    Array.from(buildfsEventsArgs.entries()).map(([idx, e]) => [
-      e.prebuildEventId,
-      buildfsEvents[idx],
-    ]),
-  );
-
-  const prebuildEventsArgs = prebuildEventsWithInspection.map((prebuildEvent) => {
-    const { inspection, project } = prebuildEvent;
-    const buildfsEvent = buildfsEventByPrebuildEventId.get(prebuildEvent.id);
-
-    const [buildfsEventId, tasks, workspaceTasks] =
-      inspection === null
-        ? [null, [], []]
-        : [
-            buildfsEvent?.event.id ?? null,
-            inspection.projectConfig.tasks.map((task) => ({
-              command: task.prebuild,
-              cwd: path.join(PREBUILD_REPOSITORY_DIR, project.rootDirectoryPath),
-            })),
-            inspection.projectConfig.tasks.map((task) => ({
-              commandShell: task.workspaceShell ?? "bash",
-              command: task.workspace,
-            })),
-          ];
-    return {
-      prebuildEventId: prebuildEvent.id,
-      buildfsEventId,
-      tasks,
-      workspaceTasks,
-    };
-  });
-
-  const updatedPrebuildEvents = (await initPrebuildEvents(prebuildEventsArgs)).map((e) => ({
-    ...e,
-    sourceProjectDrivePath: unwrap(gitObjectIdToCheckOutPath.get(e.gitObjectId)),
-  }));
-  const buildfsEventIdAndPrebuilds = Array.from(
-    groupBy(
-      updatedPrebuildEvents,
-      (e) => e.buildfsEventId,
-      (e) => e,
-    ).entries(),
-  ).sort(([a], [b]) => numericOrNullSort(a, b));
-
-  await waitForPromisesWorkflow(
-    buildfsEventIdAndPrebuilds.map(async ([buildfsEventId, innerPrebuildEvents]) => {
-      await waitForPromisesWorkflow(
-        innerPrebuildEvents.map((e) =>
-          changePrebuildEventStatus(e.id, "PREBUILD_EVENT_STATUS_RUNNING"),
-        ),
-      );
-      if (buildfsEventId != null) {
-        const buildfsEvent = unwrap(buildfsEventByPrebuildEventId.get(innerPrebuildEvents[0].id));
-        if (buildfsEvent.status === "created") {
-          const buildfsResult = await executeChild(runBuildfs, { args: [buildfsEventId] });
-          if (!buildfsResult.buildSuccessful) {
-            await cancelPrebuilds(innerPrebuildEvents.map((e) => e.id));
-            return;
-          }
-        } else if (buildfsEvent.status === "found") {
-          const twoHours = 2 * 1000 * 60 * 60;
-          try {
-            await waitForBuildfs(buildfsEventId, twoHours);
-          } catch {
-            await cancelPrebuilds(innerPrebuildEvents.map((e) => e.id));
-            return;
-          }
-        }
-      }
-      await waitForPromisesWorkflow(
-        innerPrebuildEvents.map(async (e) =>
-          executeChild(runPrebuild, {
-            args: [e.id, unwrap(e.sourceProjectDrivePath)],
-          }),
-        ),
-      );
-    }),
-  );
-}
-
-export async function runBuildfs(buildfsEventId: bigint): Promise<{ buildSuccessful: boolean }> {
-  try {
-    return await buildfs({ buildfsEventId });
-  } catch (err) {
-    logger.error(displayError(err));
-    return { buildSuccessful: false };
-  }
-}
-
-export async function runPrebuild(
-  prebuildEventId: bigint,
-  sourceProjectDrivePath: string,
-): Promise<void> {
-  await createPrebuildFiles({
-    prebuildEventId,
-    sourceProjectDrivePath,
-  });
-  const prebuildOutput = await prebuild({ prebuildEventId });
-  const prebuildTasksFailed = prebuildOutput.some((o) => o.status === "VM_TASK_STATUS_ERROR");
-  await changePrebuildEventStatus(
-    prebuildEventId,
-    prebuildTasksFailed ? "PREBUILD_EVENT_STATUS_ERROR" : "PREBUILD_EVENT_STATUS_SUCCESS",
-  );
-}
 
 export async function runCreateWorkspace(args: {
   name: string;

--- a/app/agent/workflows/prebuild.ts
+++ b/app/agent/workflows/prebuild.ts
@@ -19,11 +19,6 @@ import { ArbitraryKeyMap } from "../utils/arbitrary-key-map.server";
 const {
   checkoutAndInspect,
   fetchRepository,
-  getOrCreateBuildfsEvents,
-  getPrebuildEvents,
-  cancelPrebuilds,
-  changePrebuildEventStatus,
-  initPrebuildEvents,
   waitForBuildfs,
   buildfs,
   prebuild,
@@ -35,6 +30,19 @@ const {
   // are running at the same time, it may take a long time for all of them
   // to finish.
   startToCloseTimeout: "24 hours",
+  retry: {
+    maximumAttempts: 1,
+  },
+});
+
+const {
+  getOrCreateBuildfsEvents,
+  getPrebuildEvents,
+  cancelPrebuilds,
+  changePrebuildEventStatus,
+  initPrebuildEvents,
+} = proxyActivities<Activities>({
+  startToCloseTimeout: "1 minute",
   retry: {
     maximumAttempts: 1,
   },

--- a/app/agent/workflows/prebuild.ts
+++ b/app/agent/workflows/prebuild.ts
@@ -1,5 +1,11 @@
 import { proxyActivities, uuid4, executeChild, ApplicationFailure } from "@temporalio/workflow";
 import path from "path-browserify";
+
+import type { CheckoutAndInspectResult } from "../activities-types";
+import { HOST_PERSISTENT_DIR } from "../constants";
+import { PREBUILD_REPOSITORY_DIR } from "../prebuild-constants";
+import { ArbitraryKeyMap } from "../utils/arbitrary-key-map.server";
+
 import type { Activities } from "~/agent/activities/list";
 import { waitForPromisesWorkflow } from "~/temporal/utils";
 import {
@@ -10,11 +16,6 @@ import {
   numericOrNullSort,
   displayError,
 } from "~/utils.shared";
-
-import type { CheckoutAndInspectResult } from "../activities-types";
-import { HOST_PERSISTENT_DIR } from "../constants";
-import { PREBUILD_REPOSITORY_DIR } from "../prebuild-constants";
-import { ArbitraryKeyMap } from "../utils/arbitrary-key-map.server";
 
 const { checkoutAndInspect, fetchRepository, buildfs, prebuild, createPrebuildFiles } =
   proxyActivities<Activities>({

--- a/app/agent/workflows/prebuild.ts
+++ b/app/agent/workflows/prebuild.ts
@@ -108,7 +108,7 @@ async function runBuildfsAndPrebuildsInner(prebuildEventIds: bigint[]): Promise<
   }
   const projectAndGitObjectIdToPrebuildEvent = new ArbitraryKeyMap<
     { projectId: bigint; gitObjectId: bigint },
-    typeof prebuildEvents[0]
+    (typeof prebuildEvents)[0]
   >(({ projectId, gitObjectId }) => `${projectId}-${gitObjectId}`);
   for (const prebuildEvent of prebuildEvents) {
     const key = { projectId: prebuildEvent.projectId, gitObjectId: prebuildEvent.gitObjectId };
@@ -161,7 +161,7 @@ async function runBuildfsAndPrebuildsInner(prebuildEventIds: bigint[]): Promise<
     }),
   );
 
-  const prebuildEventsWithInspection: (typeof prebuildEvents[0] & {
+  const prebuildEventsWithInspection: ((typeof prebuildEvents)[0] & {
     inspection: CheckoutAndInspectResult;
   })[] = [];
   for (const [

--- a/app/agent/workflows/prebuild.ts
+++ b/app/agent/workflows/prebuild.ts
@@ -1,0 +1,269 @@
+import { proxyActivities, uuid4, executeChild, ApplicationFailure } from "@temporalio/workflow";
+import path from "path-browserify";
+import type { Activities } from "~/agent/activities/list";
+import { waitForPromisesWorkflow } from "~/temporal/utils";
+import {
+  groupBy,
+  numericSort,
+  unwrap,
+  filterNull,
+  numericOrNullSort,
+  displayError,
+} from "~/utils.shared";
+
+import type { CheckoutAndInspectResult } from "../activities-types";
+import { HOST_PERSISTENT_DIR } from "../constants";
+import { PREBUILD_REPOSITORY_DIR } from "../prebuild-constants";
+import { ArbitraryKeyMap } from "../utils/arbitrary-key-map.server";
+
+const {
+  checkoutAndInspect,
+  fetchRepository,
+  getOrCreateBuildfsEvents,
+  getPrebuildEvents,
+  cancelPrebuilds,
+  changePrebuildEventStatus,
+  initPrebuildEvents,
+  waitForBuildfs,
+  buildfs,
+  prebuild,
+  createPrebuildFiles,
+} = proxyActivities<Activities>({
+  // Setting this too low may cause activities such as buildfs to fail.
+  // Buildfs in particular waits on a file lock to obtain a lock on its
+  // project filesystem, so if several buildfs activities for the same project
+  // are running at the same time, it may take a long time for all of them
+  // to finish.
+  startToCloseTimeout: "24 hours",
+  retry: {
+    maximumAttempts: 1,
+  },
+});
+
+export async function runBuildfs(buildfsEventId: bigint): Promise<{ buildSuccessful: boolean }> {
+  try {
+    return await buildfs({ buildfsEventId });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(displayError(err));
+    return { buildSuccessful: false };
+  }
+}
+
+export async function runPrebuild(
+  prebuildEventId: bigint,
+  sourceProjectDrivePath: string,
+): Promise<void> {
+  await createPrebuildFiles({
+    prebuildEventId,
+    sourceProjectDrivePath,
+  });
+  const prebuildOutput = await prebuild({ prebuildEventId });
+  const prebuildTasksFailed = prebuildOutput.some((o) => o.status === "VM_TASK_STATUS_ERROR");
+  await changePrebuildEventStatus(
+    prebuildEventId,
+    prebuildTasksFailed ? "PREBUILD_EVENT_STATUS_ERROR" : "PREBUILD_EVENT_STATUS_SUCCESS",
+  );
+}
+
+/**
+ * WARNING: This is the hairiest function in the codebase.
+ * Prepare to spend a while understanding it.
+ *
+ * All projects must be from the same repository, otherwise
+ * this workflow will fail.
+ *
+ * Here's what this workflow does:
+ *
+ * - Fetch the repository
+ * - Checkout the git objects and inspect the project configs
+ * - Create buildfs events in the db
+ * - Create prebuild events in the db
+ * - Run buildfs tasks
+ * - Run prebuild tasks
+ */
+export async function runBuildfsAndPrebuilds(prebuildEventIds: bigint[]): Promise<void> {
+  if (prebuildEventIds.length === 0) {
+    return;
+  }
+  const prebuildEvents = await getPrebuildEvents(prebuildEventIds);
+  const gitRepositoryId = prebuildEvents[0].project.gitRepositoryId;
+  if (!prebuildEvents.every((e) => e.project.gitRepositoryId === gitRepositoryId)) {
+    throw new ApplicationFailure("All projects must be from the same repository");
+  }
+  if (!prebuildEvents.every((e) => e.status === "PREBUILD_EVENT_STATUS_PENDING_INIT")) {
+    throw new ApplicationFailure("All prebuild events must be in the pending init state");
+  }
+  const projectAndGitObjectIdToPrebuildEvent = new ArbitraryKeyMap<
+    { projectId: bigint; gitObjectId: bigint },
+    typeof prebuildEvents[0]
+  >(({ projectId, gitObjectId }) => `${projectId}-${gitObjectId}`);
+  for (const prebuildEvent of prebuildEvents) {
+    const key = { projectId: prebuildEvent.projectId, gitObjectId: prebuildEvent.gitObjectId };
+    if (projectAndGitObjectIdToPrebuildEvent.has(key)) {
+      throw new ApplicationFailure(
+        "There are multiple prebuild events for the same project and git object",
+      );
+    }
+    projectAndGitObjectIdToPrebuildEvent.set(key, prebuildEvent);
+  }
+
+  await fetchRepository(gitRepositoryId);
+  const gitObjectsById = new Map(prebuildEvents.map((e) => [e.gitObjectId, e.gitObject]));
+  const projectsById = new Map(prebuildEvents.map((e) => [e.projectId, e.project]));
+
+  const checkoutId = uuid4();
+  const gitObjectIdToCheckOutPath = new Map(
+    Array.from(gitObjectsById.values()).map((o) => [
+      o.id,
+      `${HOST_PERSISTENT_DIR}/checked-out/${checkoutId}-${o.id}.ext4` as const,
+    ]),
+  );
+  const gitObjectIdsAndProjectIds = Array.from(
+    groupBy(
+      prebuildEvents,
+      (e) => e.gitObjectId,
+      (e) => e.projectId,
+    ).entries(),
+  )
+    .map(
+      ([gitObjectId, projectIds]) =>
+        [gitObjectId, Array.from(new Set(projectIds).values()).sort(numericSort)] as const,
+    )
+    .sort(([a], [b]) => numericSort(a, b));
+
+  const checkedOutResults = await waitForPromisesWorkflow(
+    gitObjectIdsAndProjectIds.map(([gitObjectId, gitObjectProjectIds]) => {
+      const gitObject = unwrap(gitObjectsById.get(gitObjectId));
+      const projectConfigPaths = gitObjectProjectIds.map(
+        (projectId) => unwrap(projectsById.get(projectId)).rootDirectoryPath,
+      );
+      const outputDrivePath = unwrap(gitObjectIdToCheckOutPath.get(gitObjectId));
+
+      return checkoutAndInspect({
+        gitRepositoryId,
+        outputDrivePath,
+        targetBranch: gitObject.hash,
+        projectConfigPaths,
+      });
+    }),
+  );
+
+  const prebuildEventsWithInspection: (typeof prebuildEvents[0] & {
+    inspection: CheckoutAndInspectResult;
+  })[] = [];
+  for (const [
+    gitObjectIdIdx,
+    [gitObjectId, gitObjectProjectIds],
+  ] of gitObjectIdsAndProjectIds.entries()) {
+    for (const [projectIdIdx, projectId] of gitObjectProjectIds.entries()) {
+      const checkoutResult = checkedOutResults[gitObjectIdIdx][projectIdIdx];
+      const prebuildEvent = unwrap(
+        projectAndGitObjectIdToPrebuildEvent.get({ projectId, gitObjectId }),
+      );
+      prebuildEventsWithInspection.push({
+        ...prebuildEvent,
+        inspection: checkoutResult,
+      });
+    }
+  }
+  prebuildEventsWithInspection.sort((a, b) => numericSort(a.id, b.id));
+
+  const buildfsEventsArgs = filterNull(
+    prebuildEventsWithInspection.map(({ inspection, id, gitObjectId, project }) => {
+      if (inspection === null) {
+        return null;
+      }
+      return {
+        prebuildEventId: id,
+        projectId: project.id,
+        contextPath: inspection.projectConfig.image.buildContext,
+        dockerfilePath: inspection.projectConfig.image.file,
+        cacheHash: inspection.imageFileHash,
+        outputFilePath: `${HOST_PERSISTENT_DIR}/buildfs/${uuid4()}.ext4` as const,
+        projectFilePath: unwrap(gitObjectIdToCheckOutPath.get(gitObjectId)),
+      };
+    }),
+  );
+
+  const buildfsEvents = await getOrCreateBuildfsEvents(buildfsEventsArgs);
+  const buildfsEventByPrebuildEventId = new Map(
+    Array.from(buildfsEventsArgs.entries()).map(([idx, e]) => [
+      e.prebuildEventId,
+      buildfsEvents[idx],
+    ]),
+  );
+
+  const prebuildEventsArgs = prebuildEventsWithInspection.map((prebuildEvent) => {
+    const { inspection, project } = prebuildEvent;
+    const buildfsEvent = buildfsEventByPrebuildEventId.get(prebuildEvent.id);
+
+    const [buildfsEventId, tasks, workspaceTasks] =
+      inspection === null
+        ? [null, [], []]
+        : [
+            buildfsEvent?.event.id ?? null,
+            inspection.projectConfig.tasks.map((task) => ({
+              command: task.prebuild,
+              cwd: path.join(PREBUILD_REPOSITORY_DIR, project.rootDirectoryPath),
+            })),
+            inspection.projectConfig.tasks.map((task) => ({
+              commandShell: task.workspaceShell ?? "bash",
+              command: task.workspace,
+            })),
+          ];
+    return {
+      prebuildEventId: prebuildEvent.id,
+      buildfsEventId,
+      tasks,
+      workspaceTasks,
+    };
+  });
+
+  const updatedPrebuildEvents = (await initPrebuildEvents(prebuildEventsArgs)).map((e) => ({
+    ...e,
+    sourceProjectDrivePath: unwrap(gitObjectIdToCheckOutPath.get(e.gitObjectId)),
+  }));
+  const buildfsEventIdAndPrebuilds = Array.from(
+    groupBy(
+      updatedPrebuildEvents,
+      (e) => e.buildfsEventId,
+      (e) => e,
+    ).entries(),
+  ).sort(([a], [b]) => numericOrNullSort(a, b));
+
+  await waitForPromisesWorkflow(
+    buildfsEventIdAndPrebuilds.map(async ([buildfsEventId, innerPrebuildEvents]) => {
+      await waitForPromisesWorkflow(
+        innerPrebuildEvents.map((e) =>
+          changePrebuildEventStatus(e.id, "PREBUILD_EVENT_STATUS_RUNNING"),
+        ),
+      );
+      if (buildfsEventId != null) {
+        const buildfsEvent = unwrap(buildfsEventByPrebuildEventId.get(innerPrebuildEvents[0].id));
+        if (buildfsEvent.status === "created") {
+          const buildfsResult = await executeChild(runBuildfs, { args: [buildfsEventId] });
+          if (!buildfsResult.buildSuccessful) {
+            await cancelPrebuilds(innerPrebuildEvents.map((e) => e.id));
+            return;
+          }
+        } else if (buildfsEvent.status === "found") {
+          const twoHours = 2 * 1000 * 60 * 60;
+          try {
+            await waitForBuildfs(buildfsEventId, twoHours);
+          } catch {
+            await cancelPrebuilds(innerPrebuildEvents.map((e) => e.id));
+            return;
+          }
+        }
+      }
+      await waitForPromisesWorkflow(
+        innerPrebuildEvents.map(async (e) =>
+          executeChild(runPrebuild, {
+            args: [e.id, unwrap(e.sourceProjectDrivePath)],
+          }),
+        ),
+      );
+    }),
+  );
+}

--- a/app/agent/workflows/prebuild.ts
+++ b/app/agent/workflows/prebuild.ts
@@ -18,19 +18,25 @@ import {
   displayError,
 } from "~/utils.shared";
 
-const { checkoutAndInspect, fetchRepository, buildfs, prebuild, createPrebuildFiles } =
-  proxyActivities<Activities>({
-    // Setting this too low may cause activities such as buildfs to fail.
-    // Buildfs in particular waits on a file lock to obtain a lock on its
-    // project filesystem, so if several buildfs activities for the same project
-    // are running at the same time, it may take a long time for all of them
-    // to finish.
-    startToCloseTimeout: "24 hours",
-    heartbeatTimeout: "20 seconds",
-    retry: {
-      maximumAttempts: 1,
-    },
-  });
+const {
+  checkoutAndInspect,
+  fetchRepository,
+  buildfs,
+  prebuild,
+  createPrebuildFiles,
+  waitForBuildfs,
+} = proxyActivities<Activities>({
+  // Setting this too low may cause activities such as buildfs to fail.
+  // Buildfs in particular waits on a file lock to obtain a lock on its
+  // project filesystem, so if several buildfs activities for the same project
+  // are running at the same time, it may take a long time for all of them
+  // to finish.
+  startToCloseTimeout: "24 hours",
+  heartbeatTimeout: "20 seconds",
+  retry: {
+    maximumAttempts: 1,
+  },
+});
 
 const {
   getOrCreateBuildfsEvents,
@@ -41,13 +47,6 @@ const {
   cleanUpAfterPrebuildError,
 } = proxyActivities<Activities>({
   startToCloseTimeout: "1 minute",
-  retry: {
-    maximumAttempts: 1,
-  },
-});
-
-const { waitForBuildfs } = proxyActivities<Activities>({
-  startToCloseTimeout: "2 hours",
   retry: {
     maximumAttempts: 1,
   },

--- a/app/agent/workflows/prebuild.ts
+++ b/app/agent/workflows/prebuild.ts
@@ -26,6 +26,7 @@ const { checkoutAndInspect, fetchRepository, buildfs, prebuild, createPrebuildFi
     // are running at the same time, it may take a long time for all of them
     // to finish.
     startToCloseTimeout: "24 hours",
+    heartbeatTimeout: "20 seconds",
     retry: {
       maximumAttempts: 1,
     },

--- a/app/components/projects/prebuilds/task-viewer.tsx
+++ b/app/components/projects/prebuilds/task-viewer.tsx
@@ -1,0 +1,66 @@
+import type { VmTaskStatus } from "@prisma/client";
+import { Button } from "flowbite-react";
+
+import { LogViewer } from "./log-viewer";
+
+import { getPrebuildLogsPath } from "~/page-paths.shared";
+
+export interface Task {
+  status: VmTaskStatus;
+  command: string;
+  externalId?: string;
+}
+
+export interface ActiveTask {
+  logs: string;
+  idx: number;
+}
+
+export function TaskViewer(props: {
+  prebuild: { externalId: string };
+  tasks: Task[];
+  activeTask?: ActiveTask;
+}): JSX.Element {
+  const { prebuild, tasks, activeTask } = props;
+  const activeTaskExternalId = activeTask != null ? tasks[activeTask.idx].externalId : void 0;
+  const downloadLogBtn =
+    activeTaskExternalId != null ? (
+      <Button
+        href={getPrebuildLogsPath(prebuild.externalId, activeTaskExternalId)}
+        color="dark"
+        className="transition-all"
+      >
+        <i className="fa-solid fa-download mr-2"></i>
+        <span>Download Log</span>
+      </Button>
+    ) : null;
+  return (
+    <div className="flex flex-col grow" style={{ width: "calc(100% - 14rem)" }}>
+      {activeTask != null ? (
+        <>
+          <div className="border-b border-gray-700 flex">
+            <div
+              className="shrink-0 h-16 font-mono text-sm flex flex-col justify-center"
+              style={{ width: "calc(100% - 11rem)" }}
+            >
+              <p className="whitespace-nowrap overflow-y-hidden overflow-x-auto p-6">
+                {tasks[activeTask.idx].command}
+              </p>
+            </div>
+            <div className="grow flex flex-col justify-center items-center">{downloadLogBtn}</div>
+          </div>
+          <div className="grow bg-gray-900 rounded-br-lg font-mono text-sm overflow-auto">
+            <LogViewer text={activeTask.logs} />
+          </div>
+        </>
+      ) : (
+        <div className="flex-grow flex items-center justify-center">
+          <div className="text-gray-400 text-center">
+            <h1 className="text-2xl font-bold">No tasks</h1>
+            <p className="mt-4">This prebuild has no tasks associated with it.</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/projects/prebuilds/task-viewer.tsx
+++ b/app/components/projects/prebuilds/task-viewer.tsx
@@ -4,11 +4,13 @@ import { Button } from "flowbite-react";
 import { LogViewer } from "./log-viewer";
 
 import { getPrebuildLogsPath } from "~/page-paths.shared";
+import { unwrap } from "~/utils.shared";
 
 export interface Task {
   status: VmTaskStatus;
   command: string;
   externalId?: string;
+  idx: number;
 }
 
 export interface ActiveTask {
@@ -21,8 +23,15 @@ export function TaskViewer(props: {
   tasks: Task[];
   activeTask?: ActiveTask;
 }): JSX.Element {
-  const { prebuild, tasks, activeTask } = props;
-  const activeTaskExternalId = activeTask != null ? tasks[activeTask.idx].externalId : void 0;
+  const { prebuild, tasks } = props;
+  const activeTask =
+    props.activeTask != null
+      ? {
+          ...unwrap(tasks.find((t) => t.idx === props.activeTask?.idx)),
+          logs: props.activeTask.logs,
+        }
+      : void 0;
+  const activeTaskExternalId = activeTask != null ? activeTask.externalId : void 0;
   const downloadLogBtn =
     activeTaskExternalId != null ? (
       <Button
@@ -44,7 +53,7 @@ export function TaskViewer(props: {
               style={{ width: "calc(100% - 11rem)" }}
             >
               <p className="whitespace-nowrap overflow-y-hidden overflow-x-auto p-6">
-                {tasks[activeTask.idx].command}
+                {activeTask.command}
               </p>
             </div>
             <div className="grow flex flex-col justify-center items-center">{downloadLogBtn}</div>

--- a/app/routes/app/prebuilds/$prebuildExternalId.tsx
+++ b/app/routes/app/prebuilds/$prebuildExternalId.tsx
@@ -94,7 +94,7 @@ export const loader = async ({ context: { db, req } }: LoaderArgs) => {
   }
   tasks.sort((a, b) => numericSort(a.idx, b.idx));
 
-  let activeTask: (typeof tasks)[number] | undefined = tasks[activeTaskIdx];
+  let activeTask: (typeof tasks)[number] | undefined = tasks.find((t) => t.idx === activeTaskIdx);
   if (activeTask == null && tasks.length > 0) {
     activeTask = tasks[tasks.length - 1];
   }
@@ -116,6 +116,7 @@ export const loader = async ({ context: { db, req } }: LoaderArgs) => {
     idx: task.idx,
     status: task.status,
     command: task.command,
+    externalId: task.vmTaskExternalId,
   }));
 
   return json({

--- a/entrypoints/utils/setup-hocus-dev-env.ts
+++ b/entrypoints/utils/setup-hocus-dev-env.ts
@@ -98,9 +98,11 @@ export async function setupHocusDevEnv() {
   const agentConfig = injector.resolve(Token.Config).agent();
   const db = new PrismaClient({ datasources: { db: { url: agentConfig.databaseUrl } } });
 
-  const existingDevUser = await db.user.findUnique({ where: { externalId: DEV_USER_EXTERNAL_ID } });
-  if (existingDevUser) {
-    console.log("Dev user already exists, skipping setup");
+  const existingDevRepository = await db.gitRepository.findUnique({
+    where: { url: TESTS_REPO_URL },
+  });
+  if (existingDevRepository) {
+    console.log("Dev repository already exists, skipping setup");
     return;
   }
 

--- a/entrypoints/utils/setup-hocus-dev-env.ts
+++ b/entrypoints/utils/setup-hocus-dev-env.ts
@@ -98,11 +98,9 @@ export async function setupHocusDevEnv() {
   const agentConfig = injector.resolve(Token.Config).agent();
   const db = new PrismaClient({ datasources: { db: { url: agentConfig.databaseUrl } } });
 
-  const existingDevRepository = await db.gitRepository.findUnique({
-    where: { url: TESTS_REPO_URL },
-  });
-  if (existingDevRepository) {
-    console.log("Dev repository already exists, skipping setup");
+  const existingProject = await db.project.findFirst();
+  if (existingProject != null) {
+    console.log("A project already exists, skipping setup");
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "sshpk": "^1.17.0",
     "tail": "^2.2.4",
     "ts-pattern": "^4.1.2",
-    "undici": "^5.11.0",
+    "undici": "5.11.0",
     "unique-names-generator": "^4.7.1",
     "winston": "^3.8.1",
     "yaml": "^2.1.3"

--- a/prisma/migrations/20230414140124_prebuild_system_error/migration.sql
+++ b/prisma/migrations/20230414140124_prebuild_system_error/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "PrebuildEventSystemError" (
+    "id" BIGSERIAL NOT NULL,
+    "prebuildEventId" BIGINT NOT NULL,
+    "message" TEXT NOT NULL,
+    "occurredAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PrebuildEventSystemError_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PrebuildEventSystemError_prebuildEventId_key" ON "PrebuildEventSystemError"("prebuildEventId");
+
+-- AddForeignKey
+ALTER TABLE "PrebuildEventSystemError" ADD CONSTRAINT "PrebuildEventSystemError_prebuildEventId_fkey" FOREIGN KEY ("prebuildEventId") REFERENCES "PrebuildEvent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,10 +84,21 @@ model PrebuildEvent {
   workspaceTasksCommand String[]
   workspaceTasksShell   String[]
 
-  createdAt          DateTime                   @default(now()) @db.Timestamptz(3)
-  prebuildEventFiles PrebuildEventFiles[]
-  workspaces         Workspace[]
-  reservations       PrebuildEventReservation[]
+  createdAt                DateTime                   @default(now()) @db.Timestamptz(3)
+  prebuildEventFiles       PrebuildEventFiles[]
+  workspaces               Workspace[]
+  reservations             PrebuildEventReservation[]
+  /// Set if the prebuild failed because an error occurred within the application itself.
+  PrebuildEventSystemError PrebuildEventSystemError?
+}
+
+model PrebuildEventSystemError {
+  id              BigInt        @id @default(autoincrement())
+  prebuildEvent   PrebuildEvent @relation(fields: [prebuildEventId], references: [id])
+  prebuildEventId BigInt        @unique
+  message         String
+
+  occurredAt DateTime @default(now()) @db.Timestamptz(3)
 }
 
 model PrebuildEventFiles {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11290,10 +11290,10 @@ undefsafe@^2.0.5:
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
-undici@^5.11.0:
-  version "5.21.2"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.21.2.tgz#329f628aaea3f1539a28b9325dccc72097d29acd"
-  integrity sha512-f6pTQ9RF4DQtwoWSaC42P/NKlUjvezVvd9r155ohqkwFNRyBKM3f3pcty3ouusefNRyM25XhIQEbeQ46sZDJfQ==
+undici@5.11.0:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.11.0.tgz#1db25f285821828fc09d3804b9e2e934ae86fc13"
+  integrity sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==
   dependencies:
     busboy "^1.6.0"
 


### PR DESCRIPTION
Various changes to handle prebuild errors better:

- catch activity errors in workflows and set prebuild status to error
- add heartbeats to long-running activities to detect when they fail
- display prebuild system errors alongside tasks in the prebuild details view
- various bug fixes