### PR TITLE
HOC-150 Fix bug with sudo in multiline workspace tasks

### DIFF
--- a/app/agent/constants.ts
+++ b/app/agent/constants.ts
@@ -22,16 +22,19 @@ set -o xtrace
 ${task}
 `;
 
+const PASTE_START_ESCAPE_CODE = "\x1b[200~";
+const PASTE_END_ESCAPE_CODE = "\x1b[201~";
+
 /*
  * I'm including the boot time and a new line so one may easily distinguish
  * logs from different boots - I've decided to do so after starting and stopping the vm multiple times :)
  */
 export const TASK_INPUT_TEMPLATE = (task: string, cwd: string) =>
   `
-# Hocus task boot time ${Date.now()}
+${PASTE_START_ESCAPE_CODE}# Time: ${new Date().toLocaleString()}
 source "${WORKSPACE_ENV_SCRIPT_PATH}"
-cd ${cwd}
-${task}
+cd ${cwd}${PASTE_END_ESCAPE_CODE}
+${PASTE_START_ESCAPE_CODE}${task}${PASTE_END_ESCAPE_CODE}
 `;
 
 export const ATTACH_TO_TASK_SCRIPT_TEMPLATE = (socketPath: string, logPath: string) => `#!/bin/bash


### PR DESCRIPTION
If a workspace task included sudo in it, for example:

```
echo 1
sudo echo 2
echo 3
```

Then only the commands up to and including the one with sudo would be run. This is because we execute the workspace task by writing it char by char into a virtual terminal created with [dtach](https://github.com/hocus-dev/dtach), and sudo hijacks the TTY it's running in to read a password, even when it doesn't need it. Essentially, sudo eats up the following commands.

This PR fixes it by enclosing the workspace task in escape codes that signify that the text is being pasted. This ensures that the underlying shell won't start executing the command before it gets everything, and the tty will be clear before sudo starts reading from it.