### PR TITLE
Block registry GC

### DIFF
--- a/app/agent/block-registry/registry.service.test.ts
+++ b/app/agent/block-registry/registry.service.test.ts
@@ -345,7 +345,7 @@ test.concurrent(
 );
 
 test.concurrent(
-  "commitContainer without removing the container",
+  "Test commit without removing the container",
   testEnv.run(async ({ brService }) => {
     const c1 = await brService.createContainer(void 0, "c1", { mkfs: true, sizeInGB: 64 });
     const im1 = await brService.commitContainer(c1, "im1", { removeContainer: false });
@@ -742,11 +742,12 @@ test.concurrent(
     });
     try {
       const tag = `localhost:${port}/hocus/push-test:tag-1`;
-      await brService.pushImage(im3, {
+      const opts = {
         tag,
         username: "username",
         password: "password",
-      });
+      };
+      await waitForPromises([brService.pushImage(im3, opts), brService.pushImage(im3, opts)]);
       const im4 = await brService.loadImageFromRemoteRepo(tag, "im4", { skipVerifyTls: true });
       const { mountPoint: mountPoint2 } = await brService.expose(im4, EXPOSE_METHOD.HOST_MOUNT);
       await expect(fs.readFile(path.join(mountPoint2, "test"), "utf-8")).resolves.toEqual(

--- a/app/agent/block-registry/registry.service.ts
+++ b/app/agent/block-registry/registry.service.ts
@@ -6,8 +6,8 @@ import * as path from "path";
 import type { Static, TSchema } from "@sinclair/typebox";
 import { type DefaultLogger } from "@temporalio/worker";
 import { flock } from "fs-ext";
-import type { A, Any } from "ts-toolbelt";
-import { S } from "ts-toolbelt";
+import { match } from "ts-pattern";
+import { A, Any, F } from "ts-toolbelt";
 import { v4 as uuidv4 } from "uuid";
 
 import { execCmd, execCmdWithOpts } from "../utils";
@@ -35,6 +35,13 @@ export const EXPOSE_METHOD = {
   HOST_MOUNT: "EXPOSE_METHOD_HOST_MOUNT",
 } as const;
 export type EXPOSE_METHOD = valueof<typeof EXPOSE_METHOD>;
+
+export const CONTENT_TYPE = {
+  IMAGE: "CONTENT_TYPE_IMAGE",
+  CONTAINER: "CONTENT_TYPE_CONTAINER",
+  ANY: "CONTENT_TYPE_ANY",
+} as const;
+export type CONTENT_TYPE = valueof<typeof CONTENT_TYPE>;
 
 const catchIgnore = (toIgnore: string) => (err: any) => {
   if (!err?.message?.startsWith(toIgnore)) throw err;
@@ -118,12 +125,12 @@ export class BlockRegistryService {
     };
   }
 
-  private genObdResultPath(what: ContainerId | ImageId): string {
-    return path.join(this.paths.run, `obd-result-${what}`);
+  private genObdResultPath(contentId: ContainerId | ImageId): string {
+    return path.join(this.paths.run, `obd-result-${contentId}`);
   }
 
-  private genBlockConfigPath(what: ContainerId | ImageId): string {
-    return path.join(this.paths.blockConfig, what);
+  private genBlockConfigPath(contentId: ContainerId | ImageId): string {
+    return path.join(this.paths.blockConfig, contentId);
   }
 
   static genTCMUSubtype(length = 14): string {
@@ -152,6 +159,10 @@ export class BlockRegistryService {
 
   static isContainerId(id: string): id is ContainerId {
     return id.startsWith("ct_");
+  }
+
+  static isContentId(id: string): id is ContainerId | ImageId {
+    return id.startsWith("ct_") || id.startsWith("im_");
   }
 
   // Called once after agent restart/start
@@ -245,7 +256,9 @@ export class BlockRegistryService {
           logPath: path.join(this.paths.logs, "overlaybd.log"),
         },
         cacheConfig: {
+          // Use the download file for the RegistryFS cache :)
           cacheType: "download",
+          // Those options don't apply to the download cache
           cacheDir: this.paths.obdRegistryCache,
           cacheSizeGB: 4,
         },
@@ -332,11 +345,13 @@ export class BlockRegistryService {
     // For that do a full HBA scan
     const tcmuSubtype = await this.getTCMUSubtype();
     const dirs = await fs.readdir(this.paths.tcmuHBA);
+    // Don't use listExposedContent as this implementation works well and will still work if someone changes
+    // listExposedContent in the future and introduce bugs
     await waitForPromises(
       dirs
         .filter((tcmuStorageObjectId) => tcmuStorageObjectId.startsWith(`${tcmuSubtype}_`))
         .map((tcmuStorageObjectId) => tcmuStorageObjectId.substring(tcmuSubtype.length + 1))
-        .map((registryId) => this.hide(registryId as ImageId | ContainerId)),
+        .map((contentId) => this.hide(contentId as ImageId | ContainerId)),
     );
   }
 
@@ -438,41 +453,62 @@ export class BlockRegistryService {
     manifest: OCIImageManifest,
     layersToLoad: [string, OCIDescriptor][],
   ): Promise<ImageId> {
-    // We have the data locally so this should be fairly quick
-    for (const [layerPath, layerDescriptor] of layersToLoad) {
-      await this.loadLocalLayer(layerPath, layerDescriptor);
+    const loadSignals: string[] = [];
+    try {
+      // We have the data locally so this should be fairly quick
+      for (const [layerPath, layerDescriptor] of layersToLoad) {
+        const signal = path.join(this.paths.run, `load-signal-${this.genRandId()}`);
+        loadSignals.push(signal);
+        await this.loadLocalLayer(layerPath, layerDescriptor, signal);
+      }
+
+      // Ok the blobs were loaded, time to write the image manifest :)
+      if (
+        !(await this.idempotentConfigWrite<OCIImageManifest>(
+          manifest,
+          path.join(this.paths.images, imageId),
+        ))
+      ) {
+        throw new Error(`Image with id ${imageId} already exists`);
+      }
+
+      // Ok, almost done, generate a config for OBD
+      await this.idempotentConfigWrite<OBDConfig>(
+        {
+          lowers: this.imageManifestToOBDLowers(manifest),
+          resultFile: this.genObdResultPath(imageId),
+          hocusImageId: imageId,
+        },
+        this.genBlockConfigPath(imageId),
+      );
+
+      return imageId;
+    } finally {
+      // Release the load signals
+      await waitForPromises(loadSignals.map((x) => fs.unlink(x).catch(() => {})));
     }
-
-    // Ok the blobs were loaded, time to write the image manifest :)
-    if (
-      !(await this.idempotentConfigWrite<OCIImageManifest>(
-        manifest,
-        path.join(this.paths.images, imageId),
-      ))
-    ) {
-      throw new Error(`Image with id ${imageId} already exists`);
-    }
-
-    // Ok, almost done, generate a config for OBD
-    await this.idempotentConfigWrite<OBDConfig>(
-      {
-        lowers: this.imageManifestToOBDLowers(manifest),
-        resultFile: this.genObdResultPath(imageId),
-        hocusImageId: imageId,
-      },
-      this.genBlockConfigPath(imageId),
-    );
-
-    return imageId;
   }
 
-  private async loadLocalLayer(srcPath: string, layerDescriptor: OCIDescriptor): Promise<void> {
+  private async loadLocalLayer(
+    srcPath: string,
+    layerDescriptor: OCIDescriptor,
+    loadSignalPath: string,
+  ): Promise<void> {
     // Path to the blob in the ingest
     const sharedOCIBlobPath = this.getPathToBlob(this.paths.sharedOCIBlobsDir, layerDescriptor);
     const dstDir = path.join(this.paths.layers, layerDescriptor.digest);
     await fs.mkdir(dstDir).catch(catchAlreadyExists);
+    // If a hardlink exists on this file then loading is in progress and the layer won't be GCed
+    // We can't use overlaybd.commit for this as we may have a sealed layer or a lazy downloaded layer
+    // First ensure the signal exists by opening and closing the file in append mode
+    // If open failed then GC managed to delete this layer before we signaled a load was in progress
+    const layerLoadSignal = path.join(dstDir, ".loadSignal");
+    await (await fs.open(layerLoadSignal, "a")).close();
+    // Now we need to hardlink it. If the hardlink was created then we can be sure the layer won't be deleted by GC
+    // If this fails then it means that GC deleted the folder and we need to restart the operation :(
+    await fs.link(layerLoadSignal, loadSignalPath);
     // This should be the root of the layer, hardlinks should point to that inode
-    const dstPath = path.join(dstDir, "layer.tar");
+    const dstPath = path.join(dstDir, "overlaybd.commit");
     // Hardlink the blob from the src to the layers directory
     if (srcPath !== dstPath) {
       await fs.link(srcPath, dstPath).catch(async (err) => {
@@ -556,7 +592,7 @@ export class BlockRegistryService {
 
   private imageManifestToOBDLowers(manifest: OCIImageManifest): OBDConfig["lowers"] {
     return manifest.layers.map((layerDescriptor) => ({
-      file: path.join(this.paths.layers, layerDescriptor.digest, "layer.tar"),
+      file: path.join(this.paths.layers, layerDescriptor.digest, "overlaybd.commit"),
     }));
   }
 
@@ -634,8 +670,8 @@ export class BlockRegistryService {
     const imageId = BlockRegistryService.genImageId(outputId);
 
     // If the container does not exist and the output image exists we do nothing due to idempotence
-    const outputImageExists = await this.hasImage(imageId);
-    const containerExists = await this.hasImage(containerId);
+    const outputImageExists = await this.hasContent(imageId);
+    const containerExists = await this.hasContent(containerId);
 
     // We have 4 cases:
     // - If the output image exists and we don't have the container then:
@@ -709,13 +745,11 @@ export class BlockRegistryService {
       };
       manifest.layers.push(layerDescriptor);
 
+      // Loading the new image must happen before deleting the source container
+      // as the source container holds a reference to the lower layers and protects them against GC
       await this._loadLocalOCIImage(imageId, manifest, [[layerPath, layerDescriptor]]);
       if (opts.removeContainer) {
-        await fs.unlink(this.genBlockConfigPath(containerId)).catch(catchIgnore("ENOENT"));
-        await fs.rm(path.join(this.paths.containers, containerId), {
-          recursive: true,
-          force: true,
-        });
+        await this._removeContent(containerId);
       }
       return imageId;
     });
@@ -795,7 +829,7 @@ export class BlockRegistryService {
   }
 
   async expose<M extends EXPOSE_METHOD>(
-    what: ImageId | ContainerId,
+    contentId: ImageId | ContainerId,
     method: M,
   ): Promise<
     PickOne<
@@ -806,21 +840,23 @@ export class BlockRegistryService {
       M
     >
   > {
-    if (!BlockRegistryService.isImageId(what) && !BlockRegistryService.isContainerId(what)) {
-      throw new Error(`Invalid id: ${what}`);
+    if (!BlockRegistryService.isContentId(contentId)) {
+      throw new Error(`Invalid id: ${contentId}`);
     }
-    const readonly = BlockRegistryService.isImageId(what);
+    const readonly = BlockRegistryService.isImageId(contentId);
     switch (method) {
       case EXPOSE_METHOD.HOST_MOUNT: {
-        const bd = await this.expose(what, EXPOSE_METHOD.BLOCK_DEV);
-        const mountPoint = path.join(this.paths.mounts, what);
+        const bd = await this.expose(contentId, EXPOSE_METHOD.BLOCK_DEV);
+        const mountPoint = path.join(this.paths.mounts, contentId);
         await fs.mkdir(mountPoint).catch(catchAlreadyExists);
         try {
           let flags = readonly ? ["--read-only"] : ["--read-write", "-o", "discard"];
           const t1 = performance.now();
           // TODO: Calling the mount syscall directly is much much faster
           await execCmd("mount", ...flags, bd.device, mountPoint);
-          this.logger.info(`mount for ${what} took: ${(performance.now() - t1).toFixed(2)} ms`);
+          this.logger.info(
+            `mount for ${contentId} took: ${(performance.now() - t1).toFixed(2)} ms`,
+          );
         } catch (err: any) {
           if (!err?.message?.includes("already mounted")) throw err;
         }
@@ -830,7 +866,7 @@ export class BlockRegistryService {
         const t1 = performance.now();
         // Get the tcmuSubtype
         const tcmuSubtype = await this.getTCMUSubtype();
-        const tcmuStorageObjectId = `${tcmuSubtype}_${what}`;
+        const tcmuStorageObjectId = `${tcmuSubtype}_${contentId}`;
         const tcmuPath = path.join(this.paths.tcmuHBA, tcmuStorageObjectId);
         // Create a storage object on that HBA, if it already exists then check for a LUN
         let aluaMembers: string[] = [];
@@ -913,7 +949,9 @@ export class BlockRegistryService {
             await fs
               .writeFile(
                 path.join(tcmuPath, "control"),
-                `dev_config=${tcmuSubtype}/${this.genBlockConfigPath(what)},nl_reply_supported=-1`,
+                `dev_config=${tcmuSubtype}/${this.genBlockConfigPath(
+                  contentId,
+                )},nl_reply_supported=-1`,
               )
               .catch(catchAlreadyExists);
 
@@ -933,7 +971,7 @@ export class BlockRegistryService {
           // https://linear.app/hocus-dev/issue/HOC-204/modify-overlaybd-tcmu-to-work-without-netlink-and-expose-a-grpc-api
           for (let i = 0; i < 100; i += 1) {
             try {
-              obdResult = await fs.readFile(this.genObdResultPath(what), "utf-8");
+              obdResult = await fs.readFile(this.genObdResultPath(contentId), "utf-8");
             } catch (err) {
               if (!(err as Error).message.startsWith("ENOENT")) throw err;
               await sleep(5);
@@ -1073,7 +1111,9 @@ export class BlockRegistryService {
         }
 
         this.logger.info(
-          `Setting up block device for ${what} took: ${(performance.now() - t1).toFixed(2)} ms`,
+          `Setting up block device for ${contentId} took: ${(performance.now() - t1).toFixed(
+            2,
+          )} ms`,
         );
 
         return {
@@ -1085,13 +1125,13 @@ export class BlockRegistryService {
     assert(false, "Unreachable");
   }
 
-  async hide(what: ImageId | ContainerId): Promise<void> {
-    if (!BlockRegistryService.isImageId(what) && !BlockRegistryService.isContainerId(what)) {
-      throw new Error(`Invalid id: ${what}`);
+  async hide(contentId: ImageId | ContainerId): Promise<void> {
+    if (!BlockRegistryService.isContentId(contentId)) {
+      throw new Error(`Invalid id: ${contentId}`);
     }
     const t1 = performance.now();
     // Ensure the device was unmounted
-    const mountPoint = path.join(this.paths.mounts, what);
+    const mountPoint = path.join(this.paths.mounts, contentId);
     const dirPresent = await doesFileExist(mountPoint);
     if (dirPresent) {
       try {
@@ -1105,7 +1145,7 @@ export class BlockRegistryService {
     }
     // Remove the TCMU <-> LUN mapping
     const tcmuSubtype = await this.getTCMUSubtype();
-    const tcmuStorageObjectId = `${tcmuSubtype}_${what}`;
+    const tcmuStorageObjectId = `${tcmuSubtype}_${contentId}`;
     const tcmuPath = path.join(this.paths.tcmuHBA, tcmuStorageObjectId);
     const aluaMembers = await this.getTCMUAluaMembers(tcmuStorageObjectId).catch(
       catchIgnore("ENOENT"),
@@ -1127,12 +1167,234 @@ export class BlockRegistryService {
     // Remove the TCMU storage object
     await fs.rmdir(tcmuPath).catch(catchIgnore("ENOENT"));
     // Remove the result file
-    await fs.unlink(this.genObdResultPath(what)).catch(catchIgnore("ENOENT"));
-    this.logger.info(`hide of ${what} took: ${(performance.now() - t1).toFixed(2)} ms`);
+    await fs.unlink(this.genObdResultPath(contentId)).catch(catchIgnore("ENOENT"));
+    this.logger.info(`hide of ${contentId} took: ${(performance.now() - t1).toFixed(2)} ms`);
   }
 
-  async hasImage(what: ImageId | ContainerId): Promise<boolean> {
-    return await doesFileExist(this.genBlockConfigPath(what));
+  async hasContent(contentId: ImageId | ContainerId): Promise<boolean> {
+    return await doesFileExist(this.genBlockConfigPath(contentId));
+  }
+
+  /* Warning: The only way to get the block device/mount point is to call the expose method again
+   * This should be used mostly for introspection/debugging as this will return true if the expose method
+   * was interrupted and didn't finish
+   */
+  async wasExposed(contentId: ImageId | ContainerId): Promise<boolean> {
+    const tcmuSubtype = await this.getTCMUSubtype();
+    const tcmuStorageObjectId = `${tcmuSubtype}_${contentId}`;
+    const tcmuPath = path.join(this.paths.tcmuHBA, tcmuStorageObjectId);
+    return await doesFileExist(tcmuPath);
+  }
+
+  /* Warning: The only way to get the block device/mount point is to call the expose method again
+   * This should be used mostly for introspection/debugging as this will return true if the expose method
+   * was interrupted and didn't finish
+   */
+  async listExposedContent<T extends CONTENT_TYPE>(
+    contentType: T = CONTENT_TYPE.ANY as T,
+  ): Promise<
+    PickOne<
+      {
+        [CONTENT_TYPE.ANY]: ImageId | ContainerId;
+        [CONTENT_TYPE.IMAGE]: ImageId;
+        [CONTENT_TYPE.CONTAINER]: ContainerId;
+      },
+      T
+    >[]
+  > {
+    const res = [];
+    const filterF = match(contentType as CONTENT_TYPE)
+      .with(CONTENT_TYPE.ANY, () => BlockRegistryService.isContentId)
+      .with(CONTENT_TYPE.CONTAINER, () => BlockRegistryService.isContainerId)
+      .with(CONTENT_TYPE.IMAGE, () => BlockRegistryService.isImageId)
+      .exhaustive();
+    const tcmuSubtype = await this.getTCMUSubtype();
+    const dirs = await fs.readdir(this.paths.tcmuHBA);
+    const ids = dirs
+      .filter((tcmuStorageObjectId) => tcmuStorageObjectId.startsWith(`${tcmuSubtype}_`))
+      .map((tcmuStorageObjectId) => tcmuStorageObjectId.substring(tcmuSubtype.length + 1));
+    for (const id of ids) {
+      if (filterF(id)) res.push(id);
+    }
+    return res as any;
+  }
+
+  async listContent<T extends CONTENT_TYPE>(
+    contentType: T = CONTENT_TYPE.ANY as T,
+  ): Promise<
+    PickOne<
+      {
+        [CONTENT_TYPE.ANY]: ImageId | ContainerId;
+        [CONTENT_TYPE.IMAGE]: ImageId;
+        [CONTENT_TYPE.CONTAINER]: ContainerId;
+      },
+      T
+    >[]
+  > {
+    const res = [];
+    const filterF = match(contentType as CONTENT_TYPE)
+      .with(CONTENT_TYPE.ANY, () => BlockRegistryService.isContentId)
+      .with(CONTENT_TYPE.CONTAINER, () => BlockRegistryService.isContainerId)
+      .with(CONTENT_TYPE.IMAGE, () => BlockRegistryService.isImageId)
+      .exhaustive();
+    for (const filename of await fs.readdir(this.paths.blockConfig)) {
+      if (filterF(filename)) res.push(filename);
+    }
+    return res as any;
+  }
+
+  async removeContent(contentId: ImageId | ContainerId): Promise<void> {
+    if (!BlockRegistryService.isContentId(contentId)) {
+      throw new Error(`Invalid id: ${contentId}`);
+    }
+    // Ensure the content is hidden
+    await this.hide(contentId);
+    await this._removeContent(contentId);
+  }
+
+  private async _removeContent(contentId: ImageId | ContainerId): Promise<void> {
+    // The block config defines if something is available in the registry
+    await fs.unlink(this.genBlockConfigPath(contentId)).catch(catchIgnore("ENOENT"));
+    if (BlockRegistryService.isContainerId(contentId)) {
+      // By definition a writable container layer can't be shared among
+      // multiple tags so we just deleted the only reference to this layer
+      await fs.rm(path.join(this.paths.containers, contentId), {
+        recursive: true,
+        force: true,
+      });
+    }
+    if (BlockRegistryService.isImageId(contentId)) {
+      // The OCI manifest is not longer necessary
+      // Blobs may have multiple xrefs on the disk so we need to
+      await fs.unlink(path.join(this.paths.images, contentId)).catch(catchIgnore("ENOENT"));
+    }
+  }
+
+  private async estimateDirStorageUsage(path: string): Promise<bigint> {
+    // Don't use -b as it implies --apparent-size which fails on sparse files
+    const du = await execCmd("du", "-s", "--block-size=1", path);
+    return BigInt(du.stdout.split("\t")[0]);
+  }
+
+  async estimateStorageUsage(): Promise<{
+    layers: bigint;
+    containers: bigint;
+    // > 0 when when lazy pulling is enabled and we operate in ocf cache mode with download disabled
+    obdRegistryCache: bigint;
+    // > 0 when FastOCI is in use OR we use gzipped layers and not zfile
+    obdGzipCache: bigint;
+  }> {
+    const [layers, containers, obdRegistryCache, obdGzipCache] = await waitForPromises(
+      [
+        this.paths.layers,
+        this.paths.containers,
+        this.paths.obdRegistryCache,
+        this.paths.obdGzipCache,
+      ].map(this.estimateDirStorageUsage),
+    );
+    return {
+      layers,
+      containers,
+      obdRegistryCache,
+      obdGzipCache,
+    };
+  }
+
+  async garbageCollect(): Promise<void> {
+    // This is fully lockless and should even work when someone runs this method concurrently(due to a bug)
+    // Special carefulness must be employed in this method as the registry is lockless and delete/loadImage operations
+    // might run concurrently. The algorithm is as follows:
+    // 1. Gather a list of all resources on the disk and check their hardlink count on their load signal
+    // 2. Load all block configs and calculate the set of referenced resources
+    // 3. Delete all resources which are unreferenced and are not signaled
+    const [allManifests, allLayers, allContainers] = await waitForPromises([
+      fs.readdir(this.paths.images).then((x) => x.filter(BlockRegistryService.isImageId)),
+      // Only consider the layer directory, the shared oci dir will be removed when lazy pulling will be enabled
+      // Blobs are still deleted from the shared dir but a dangling file in the shared dir won't be deleted
+      fs.readdir(this.paths.layers).then((x) => x.filter((y) => y.startsWith("sha256:"))),
+      fs.readdir(this.paths.containers).then((x) => x.filter(BlockRegistryService.isContainerId)),
+    ]);
+
+    // Skip any signaled layers, this is needed as otherwise there is a race where we might delete an already loaded image
+    const allDigests: string[] = [];
+    await waitForPromises(
+      allLayers.map(async (layerDigest) => {
+        const stat = await fs.stat(path.join(this.paths.layers, layerDigest, ".loadSignal"));
+        if (stat.nlink === 1) allDigests.push(layerDigest);
+      }),
+    );
+    const referencedManifests = new Set<ImageId>();
+    const referencedContainers = new Set<ContainerId>();
+    const referencedLayers = new Set<string>();
+    const allConfigs = await fs
+      .readdir(this.paths.blockConfig)
+      .then((ids) =>
+        waitForPromises(
+          ids.map((id) =>
+            readJsonFileOfType(path.join(this.paths.blockConfig, id), OBDConfigValidator).catch(
+              () => ({ lowers: [], resultFile: "" } as OBDConfig),
+            ),
+          ),
+        ),
+      );
+    // Calculate the reference counts based on configs. This will also work with container sealing and lazy pulling
+    for (const config of allConfigs) {
+      if (config.hocusImageId) {
+        if (BlockRegistryService.isImageId(config.hocusImageId)) {
+          referencedManifests.add(config.hocusImageId);
+        } else {
+          this.logger.error(`Found invalid image id in block config ${config.hocusImageId}`);
+        }
+      }
+      if (config.upper) {
+        const directoryName = path.basename(path.dirname(config.upper.data));
+        if (BlockRegistryService.isContainerId(directoryName)) {
+          referencedContainers.add(directoryName);
+        } else {
+          this.logger.error(`Found upper layer with invalid name ${directoryName}`);
+        }
+      }
+      for (const lower of config.lowers) {
+        const layerHash = path.basename(path.dirname(lower.file));
+        referencedLayers.add(layerHash);
+      }
+    }
+
+    // Perform garbage collection of dangling resources
+    const tasks = [];
+    for (const manifest of allManifests) {
+      if (referencedManifests.has(manifest as ImageId)) continue;
+      // Ok this manifest wasn't deleted cause removeContent was interrupted
+      tasks.push(fs.unlink(path.join(this.paths.images, manifest)).catch(catchIgnore("ENOENT")));
+    }
+    for (const container of allContainers) {
+      if (referencedContainers.has(container as ContainerId)) continue;
+      // Ok this container wasn't deleted cause removeContent was interrupted
+      tasks.push(
+        fs.rm(path.join(this.paths.containers, container), {
+          recursive: true,
+          force: true,
+        }),
+      );
+    }
+    for (const layerDigest of allDigests) {
+      if (referencedLayers.has(layerDigest)) continue;
+      tasks.push(
+        (async () => {
+          // TODO: analyze whether this actually works or the race is absurdly rare
+          const stat = await fs.stat(path.join(this.paths.layers, layerDigest, ".loadSignal"));
+          if (stat.nlink !== 1) return;
+          const [algo, hash] = layerDigest.split(":");
+          await waitForPromises([
+            fs.rm(path.join(this.paths.layers, layerDigest), { force: true, recursive: true }),
+            fs
+              .unlink(path.join(this.paths.sharedOCIBlobsDir, algo, hash))
+              .catch(catchIgnore("ENOENT")),
+          ]);
+        })(),
+      );
+    }
+    await waitForPromises(tasks);
   }
 
   private tagToRegistry(tag: string): string {
@@ -1171,7 +1433,7 @@ export class BlockRegistryService {
     const layers = manifest.layers.map((layerDescriptor) => {
       const [hashType, hash] = layerDescriptor.digest.split(":");
       return {
-        file: path.join(this.paths.layers, layerDescriptor.digest, "layer.tar"),
+        file: path.join(this.paths.layers, layerDescriptor.digest, "overlaybd.commit"),
         hashType,
         hash,
       };
@@ -1217,6 +1479,9 @@ export class BlockRegistryService {
     imageId: ImageId,
     opts: { tag: string; username: string; password: string },
   ): Promise<void> {
+    if (!BlockRegistryService.isImageId(imageId)) {
+      throw new Error(`Invalid id: ${imageId}`);
+    }
     await this.withTmpDir("export", async (exportDir) => {
       await this.exportImageForPush(imageId, exportDir);
       const registry = this.tagToRegistry(opts.tag);

--- a/app/agent/block-registry/registry.service.ts
+++ b/app/agent/block-registry/registry.service.ts
@@ -1386,7 +1386,9 @@ export class BlockRegistryService {
           if (stat.nlink !== 1) return;
           const [algo, hash] = layerDigest.split(":");
           await waitForPromises([
-            fs.rm(path.join(this.paths.layers, layerDigest), { force: true, recursive: true }),
+            fs
+              .rm(path.join(this.paths.layers, layerDigest), { force: true, recursive: true })
+              .catch(catchIgnore("ENOTEMPTY")),
             fs
               .unlink(path.join(this.paths.sharedOCIBlobsDir, algo, hash))
               .catch(catchIgnore("ENOENT")),


### PR DESCRIPTION
- Images or Containers are now both referred to as Content
- Rename `hasImage` -> `hasContent`
- Align layer naming with what Overlaybd lazy pulling expects
- Fixed concurrency bugs in `pushImage`
- Introduce new public helper methods:
 * `hasContent`
 * `wasExposed`
 * `listExposedContent`
 * `listContent`
- Allows removing containers or images using `removeContent`, backing files are deleted instantly for containers, for images `garbageCollect` needs to be ran
- Adjusts RFD-2 to align with the implementation