### PR TITLE
Increase agent healthcheck timeout

### DIFF
--- a/ops/docker/hocus-local.common.docker-compose.yml
+++ b/ops/docker/hocus-local.common.docker-compose.yml
@@ -211,8 +211,8 @@ services:
       test:
         [
           "CMD-SHELL",
-          "if [ `stat -c %Y /run/.hocus-agent-healthcheck` -ge `date +%s -d'3 seconds ago'` ]; then exit 0; else exit 1; fi",
+          "if [ `stat -c %Y /run/.hocus-agent-healthcheck` -ge `date +%s -d'5 seconds ago'` ]; then exit 0; else exit 1; fi",
         ]
       interval: 1s
-      timeout: 1s
-      retries: 7
+      timeout: 10s
+      retries: 30


### PR DESCRIPTION
Increases the agent healthcheck timeout from 7s to 30s. This aligns with the timeout for the UI container
Fixes #124