### PR TITLE
Ensure sd_mod is available on the host machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Hocus integrates with any Git provider that uses the SSH protocol, like GitHub, 
 
 - x86_64 Linux, preferably with at least the 5.10 kernel
 - KVM support on the host
-- A Linux distribution which supports the `target_core_user` and `tcm_loop` kernel modules (generally available with the notable exception of WSL https://github.com/microsoft/WSL/issues/9511)
+- A Linux distribution which supports the `target_core_user`, `tcm_loop` and `sd_mod` kernel modules (generally available with the notable exception of WSL https://github.com/microsoft/WSL/issues/9511)
 - Git
 - Docker, Docker Compose, and Buildx
 


### PR DESCRIPTION
Fixes deployment on cloud versions of Rocky Linux. Usually sd_mod is compiled into the kernel cause otherwise said kernel is unable to boot from any HDD. The kernel provided with Rocky Linux doesn't compile in sd_mod and provides it as an loadable module.